### PR TITLE
Cleaned up compile.sh

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 ARDUINO_SDK_PATH=/opt/arduino
 mkdir -p build
-${ARDUINO_SDK_PATH}/arduino-builder -dump-prefs -logger=machine -hardware "${ARDUINO_SDK_PATH}/hardware" -tools "${ARDUINO_SDK_PATH}/tools-builder" -tools "${ARDUINO_SDK_PATH}/hardware/tools/avr" -built-in-libraries "${ARDUINO_SDK_PATH}/libraries" -libraries "./lib" -fqbn=arduino:avr:pro:cpu=16MHzatmega328 -ide-version=10608 -build-path "${PWD}/build" -warnings=none -prefs=build.warn_data_percentage=75 -verbose "${PWD}/src/enclosure.ino"
-${ARDUINO_SDK_PATH}/arduino-builder -compile -logger=machine -hardware "${ARDUINO_SDK_PATH}/hardware" -tools "${ARDUINO_SDK_PATH}/tools-builder" -tools "${ARDUINO_SDK_PATH}/hardware/tools/avr" -built-in-libraries "${ARDUINO_SDK_PATH}/libraries" -libraries "./lib" -fqbn=arduino:avr:pro:cpu=16MHzatmega328 -ide-version=10608 -build-path "${PWD}/build" -warnings=none -prefs=build.warn_data_percentage=75 -verbose "${PWD}/src/enclosure.ino"
+${ARDUINO_SDK_PATH}/arduino-builder -compile -hardware "${ARDUINO_SDK_PATH}/hardware" -tools "${ARDUINO_SDK_PATH}/tools-builder" -tools "${ARDUINO_SDK_PATH}/hardware/tools/avr" -built-in-libraries "${ARDUINO_SDK_PATH}/libraries" -libraries "./lib" -fqbn=arduino:avr:pro:cpu=16MHzatmega328 -ide-version=10608 -build-path "${PWD}/build" -warnings=all -prefs=build.warn_data_percentage=75 "${PWD}/src/enclosure.ino"


### PR DESCRIPTION
This fixes #22 . This is open for discussion but I've cleaned up the compile.sh script by doing the following:
- Removed the printing of all build preferences (the only prints them to the screen. It doesn't save them to a file or anything)
- Removed the verbose flag (I don't think this is helpful since it just clogs up the output)
- Enabled all warnings (we should look into these)
- Changed from machine logging to human logging (we don't need all those strange characters)
