### PR TITLE
Created MouthAnim base class

### DIFF
--- a/lib/MycroftAnims/MouthAnim.cpp
+++ b/lib/MycroftAnims/MouthAnim.cpp
@@ -1,0 +1,7 @@
+#include "MouthAnim.h"
+
+int MouthAnim::updateDrawable(MycroftDisplay &display) {
+	display.drawFramePgm(getId(), ANIM);
+	updateId();
+	return MS_PER_FRAME;
+}

--- a/lib/MycroftAnims/MouthAnim.h
+++ b/lib/MycroftAnims/MouthAnim.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "MycroftDisplay.h"
+#include "MycroftDrawable.h"
+
+class MouthAnim : public MycroftDrawable {
+public:
+	template<size_t N>
+	MouthAnim(const char (&ANIM)[N][16], const int MS_PER_FRAME = 70);
+
+protected:
+	const char (*ANIM)[16];
+	const size_t NUM_FRAMES;
+
+private:
+	int updateDrawable(MycroftDisplay &display) override;
+	virtual void updateId() = 0;
+	virtual byte getId() = 0;
+
+	const int MS_PER_FRAME;
+};
+
+#include "MouthAnim.inl"

--- a/lib/MycroftAnims/MouthAnim.inl
+++ b/lib/MycroftAnims/MouthAnim.inl
@@ -1,0 +1,4 @@
+
+template<size_t N>
+MouthAnim::MouthAnim(const char (&ANIM)[N][16], const int MS_PER_FRAME) :
+ANIM(&(ANIM[0])), NUM_FRAMES(N), MS_PER_FRAME(MS_PER_FRAME) { }

--- a/lib/MycroftDrawable/MycroftDrawable.cpp
+++ b/lib/MycroftDrawable/MycroftDrawable.cpp
@@ -1,0 +1,24 @@
+#include "MycroftDrawable.h"
+#include "MycroftDisplay.h"
+
+MycroftDrawable::MycroftDrawable() {
+	reset();
+}
+
+void MycroftDrawable::update(MycroftDisplay &display) {
+	const unsigned long MILLIS = millis();
+	if (nextUpdate == 0)
+		return;
+	if (nextUpdate < MILLIS)
+	{
+		nextUpdate = MILLIS + updateDrawable(display);
+		display.render();
+	}
+}
+
+void MycroftDrawable::reset() {
+	nextUpdate = 1;
+	resetDrawable();
+}
+
+void MycroftDrawable::resetDrawable() { }

--- a/lib/MycroftDrawable/MycroftDrawable.h
+++ b/lib/MycroftDrawable/MycroftDrawable.h
@@ -1,0 +1,26 @@
+#pragma once
+
+class MycroftDisplay;
+
+/*
+ * Represents anything that is drawn each frame.
+ * Includes anything that draws to the matrix.
+ */
+class MycroftDrawable {
+public:
+	MycroftDrawable();
+	void update(MycroftDisplay &display);
+	void reset();
+	
+protected:
+	/*
+	 * Draws image to display.
+	 * Returns milliseconds until the next update or -1 to indicate
+	 * no subsequent update is necessary
+	 */
+	virtual int updateDrawable(MycroftDisplay &display) = 0;
+	virtual void resetDrawable();
+	
+private:
+	unsigned long nextUpdate;
+};


### PR DESCRIPTION
This relies on #38 .

This introduces a base class for various types of animations. The folder is called `MycroftAnims` because it will hold the other derived classes as well and they all are types of Mycroft animations. Placing them each in their own folder would propagate the mess that has begun to develop in the `lib` folder.

A mouth animation is simply defined as a set of frames to play in a particular pattern. This lays the framework for containing the behavior for the pattern of frames. For instance, a `ForwardAnim` class would provide the following pattern of frames for an array of size 4: `{ 0, 1, 2, 3}` and then loop whereas a `PingPongAnim` class would provide the following pattern: `{ 0, 1, 2, 3, 2, 1 }`.
