### PR TITLE
Created PingPongAnim class

### DIFF
--- a/lib/MycroftAnims/MouthAnim.cpp
+++ b/lib/MycroftAnims/MouthAnim.cpp
@@ -1,0 +1,7 @@
+#include "MouthAnim.h"
+
+int MouthAnim::updateDrawable(MycroftDisplay &display) {
+	display.drawFramePgm(getId(), ANIM);
+	updateId();
+	return MS_PER_FRAME;
+}

--- a/lib/MycroftAnims/MouthAnim.h
+++ b/lib/MycroftAnims/MouthAnim.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "MycroftDisplay.h"
+#include "MycroftDrawable.h"
+
+class MouthAnim : public MycroftDrawable {
+public:
+	template<size_t N>
+	MouthAnim(const char (&ANIM)[N][16], const int MS_PER_FRAME = 70);
+
+protected:
+	const char (*ANIM)[16];
+	const size_t NUM_FRAMES;
+
+private:
+	int updateDrawable(MycroftDisplay &display) override;
+	virtual void updateId() = 0;
+	virtual byte getId() = 0;
+
+	const int MS_PER_FRAME;
+};
+
+#include "MouthAnim.inl"

--- a/lib/MycroftAnims/MouthAnim.inl
+++ b/lib/MycroftAnims/MouthAnim.inl
@@ -1,0 +1,4 @@
+
+template<size_t N>
+MouthAnim::MouthAnim(const char (&ANIM)[N][16], const int MS_PER_FRAME) :
+ANIM(&(ANIM[0])), NUM_FRAMES(N), MS_PER_FRAME(MS_PER_FRAME) { }

--- a/lib/MycroftAnims/PingPongAnim.cpp
+++ b/lib/MycroftAnims/PingPongAnim.cpp
@@ -1,0 +1,14 @@
+#include "PingPongAnim.h"
+
+void PingPongAnim::updateId() {
+	id += dir;
+	if (id <= 0) {
+		dir = 1;
+	} else if (id >= NUM_FRAMES / 4 - 1) {
+		dir = -1;
+	}
+}
+
+byte PingPongAnim::getId() {
+	return id;
+}

--- a/lib/MycroftAnims/PingPongAnim.h
+++ b/lib/MycroftAnims/PingPongAnim.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "MouthAnim.h"
+
+class PingPongAnim : public MouthAnim {
+public:
+	using MouthAnim::MouthAnim;
+
+private:
+	void updateId() override;
+	byte getId() override;
+
+	byte id = 0;
+	int8_t dir = 1;
+};

--- a/lib/MycroftDisplay/MycroftDisplay.cpp
+++ b/lib/MycroftDisplay/MycroftDisplay.cpp
@@ -1,0 +1,50 @@
+#include "MycroftDisplay.h"
+
+MycroftDisplay::MycroftDisplay(int pinCS1, int pinWR, int pinDATA) {
+	ht1632.begin(pinCS1, pinWR, pinDATA);
+	ht1632.clear();
+	ht1632.render();
+}
+
+void MycroftDisplay::drawFrame(byte index, const char (*IMG)[16]) {
+	index *= 4;
+	for (byte panel = 0; panel < 4; ++panel) {
+		draw8x8(8 * panel, index + panel, IMG);
+	}
+}
+
+void MycroftDisplay::drawIcon(byte pos, byte index, const char (*ICONS)[16]) {
+	draw8x8(pos, index, ICONS);
+}
+
+void MycroftDisplay::drawText(String text, int8_t pos, bool small) {
+	if (small) {
+		ht1632.drawTextPgm(text.c_str(), pos, 0, FONT_5X4, FONT_5X4_WIDTH, FONT_5X4_HEIGHT, FONT_5X4_STEP_GLYPH);
+	} else {
+		ht1632.drawTextPgm(text.c_str(), pos, 0, FONT_8X4, FONT_8X4_WIDTH, FONT_8X4_HEIGHT, FONT_8X4_STEP_GLYPH);
+	}
+}
+
+void MycroftDisplay::slideText() {
+	ht1632.transition(TRANSITION_BUFFER_SWAP);
+}
+
+void MycroftDisplay::clear() {
+	ht1632.clear();
+}
+
+void MycroftDisplay::render() {
+	ht1632.render();
+}
+
+void MycroftDisplay::draw8x8(byte pos, byte index, const char (*IMG)[16]) {
+	readBuffer(index, IMG);
+	ht1632.drawImage(currentImage, 8, 8, pos, 0);
+}
+
+void MycroftDisplay::readBuffer(byte idx, const char (*IMG)[16]) {
+	byte size = sizeof (currentImage);
+	for (byte j = 0; j < size; j++) {
+		currentImage[j] = (char) pgm_read_byte(&(IMG[idx][j]));
+	}
+}

--- a/lib/MycroftDisplay/MycroftDisplay.cpp
+++ b/lib/MycroftDisplay/MycroftDisplay.cpp
@@ -6,15 +6,21 @@ MycroftDisplay::MycroftDisplay(int pinCS1, int pinWR, int pinDATA) {
 	ht1632.render();
 }
 
-void MycroftDisplay::drawFrame(byte index, const char (*IMG)[16]) {
-	index *= 4;
+void MycroftDisplay::drawFrame(const char (&IMG)[4][16]) {
 	for (byte panel = 0; panel < 4; ++panel) {
-		draw8x8(8 * panel, index + panel, IMG);
+		ht1632.drawImage(IMG[panel], 8, 8, 8 * panel, 0);
 	}
 }
 
-void MycroftDisplay::drawIcon(byte pos, byte index, const char (*ICONS)[16]) {
-	draw8x8(pos, index, ICONS);
+void MycroftDisplay::drawFramePgm(byte index, const char (*IMG)[16]) {
+	index *= 4;
+	for (byte panel = 0; panel < 4; ++panel) {
+		draw8x8Pgm(8 * panel, index + panel, IMG);
+	}
+}
+
+void MycroftDisplay::drawIconPgm(byte pos, byte index, const char (*ICONS)[16]) {
+	draw8x8Pgm(pos, index, ICONS);
 }
 
 void MycroftDisplay::drawText(String text, int8_t pos, bool small) {
@@ -37,7 +43,7 @@ void MycroftDisplay::render() {
 	ht1632.render();
 }
 
-void MycroftDisplay::draw8x8(byte pos, byte index, const char (*IMG)[16]) {
+void MycroftDisplay::draw8x8Pgm(byte pos, byte index, const char (*IMG)[16]) {
 	readBuffer(index, IMG);
 	ht1632.drawImage(currentImage, 8, 8, pos, 0);
 }

--- a/lib/MycroftDisplay/MycroftDisplay.h
+++ b/lib/MycroftDisplay/MycroftDisplay.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "MycroftHT1632.h"
+
+#include "font_5x4.h"
+#include "font_8x4.h"
+
+class MycroftDisplay {
+public:
+	MycroftDisplay(int pinCS1, int pinWR, int pinDATA);
+	void drawFrame(byte index, const char (*IMG)[16]);
+	void drawIcon(byte pos, byte index, const char (*ICONS)[16]);
+	void drawText(String text, int8_t pos, bool small);
+	void slideText();
+	void clear();
+	void render();
+
+private:
+	void draw8x8(byte pos, byte index, const char (*IMG)[16]);
+	void readBuffer(byte idx, const char (*IMG)[16]);
+
+	MycroftHT1632 ht1632;
+	char currentImage[16];
+};

--- a/lib/MycroftDisplay/MycroftDisplay.h
+++ b/lib/MycroftDisplay/MycroftDisplay.h
@@ -8,15 +8,16 @@
 class MycroftDisplay {
 public:
 	MycroftDisplay(int pinCS1, int pinWR, int pinDATA);
-	void drawFrame(byte index, const char (*IMG)[16]);
-	void drawIcon(byte pos, byte index, const char (*ICONS)[16]);
+	void drawFrame(const char (&IMG)[4][16]);
+	void drawFramePgm(byte index, const char (*IMG)[16]);
+	void drawIconPgm(byte pos, byte index, const char (*ICONS)[16]);
 	void drawText(String text, int8_t pos, bool small);
 	void slideText();
 	void clear();
 	void render();
 
 private:
-	void draw8x8(byte pos, byte index, const char (*IMG)[16]);
+	void draw8x8Pgm(byte pos, byte index, const char (*IMG)[16]);
 	void readBuffer(byte idx, const char (*IMG)[16]);
 
 	MycroftHT1632 ht1632;

--- a/lib/MycroftDrawable/MycroftDrawable.cpp
+++ b/lib/MycroftDrawable/MycroftDrawable.cpp
@@ -1,0 +1,21 @@
+#include "MycroftDrawable.h"
+#include "MycroftDisplay.h"
+
+MycroftDrawable::MycroftDrawable() { }
+
+void MycroftDrawable::update(MycroftDisplay &display) {
+	if (msTillUpdate < 0)
+		return;
+	if (--msTillUpdate <= 0)
+	{
+		msTillUpdate = updateDrawable(display);
+		display.render();
+	}
+}
+
+void MycroftDrawable::reset() {
+	msTillUpdate = 0;
+	resetDrawable();
+}
+
+void MycroftDrawable::resetDrawable() { }

--- a/lib/MycroftDrawable/MycroftDrawable.h
+++ b/lib/MycroftDrawable/MycroftDrawable.h
@@ -1,0 +1,26 @@
+#pragma once
+
+class MycroftDisplay;
+
+/*
+ * Represents anything that is drawn each frame.
+ * Includes anything that draws to the matrix.
+ */
+class MycroftDrawable {
+public:
+	MycroftDrawable();
+	void update(MycroftDisplay &display);
+	void reset();
+	
+protected:
+	/*
+	 * Draws image to display.
+	 * Returns milliseconds until the next update or -1 to indicate
+	 * no subsequent update is necessary
+	 */
+	virtual int updateDrawable(MycroftDisplay &display) = 0;
+	virtual void resetDrawable();
+	
+private:
+	int msTillUpdate;
+};


### PR DESCRIPTION
This relies on #40 .

The `PingPongAnim` class generates frame ids in a first increasing and then decreasing pattern. For example, for image data of size four this would play the following sequence of frames: `{ 0, 1, 2, 3, 2, 1 }`. The current think animation is an example of this behavior.
