### PR TITLE
Removed bug causing unintended behavior in talk animation

### DIFF
--- a/lib/MycroftMouth/MycroftMouth.cpp
+++ b/lib/MycroftMouth/MycroftMouth.cpp
@@ -63,7 +63,6 @@ void MycroftMouth::talk() {
 		total = (size * 2) - 2;
 	}
 	if (millis() > nextTime) {
-		Serial.println(total);
 		drawFrame(i, state);
 		if (i < size - 1) {
 			i++;


### PR DESCRIPTION
The mouth's animations currently rely on decreasing the variable `total`, but they didn't have any protections preventing it from dropping below 0. As a result, it was overflowing during the talk animation, causing it to endlessly repeat the last two frames instead of properly resetting. This PR resets `total` after every loop, making the talk animation loop properly.
