### PR TITLE
Added more entries to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 build
 src/enclosure
+.gch
+nbproject/


### PR DESCRIPTION
`.gch` files are generated from PlatformIO and the `nbproject/` directory is where Netbeans stores its project files.
