### PR TITLE
Added text centering, restored spinning

### DIFF
--- a/lib/EyesProcessor/EyesProcessor.cpp
+++ b/lib/EyesProcessor/EyesProcessor.cpp
@@ -41,7 +41,7 @@ void EyesProcessor::process(const String& cmd) {
 	} else if (cmd.startsWith("set")) {
                 uint8_t     pixel = 0;
                 uint32_t    color = 0;
-                
+
                 // parse the pixel #
                 byte        c = 4; // skip "set="
                 while (c < cmd.length() && cmd[c] != ',')
@@ -66,6 +66,8 @@ void EyesProcessor::process(const String& cmd) {
 	} else if (checkEyeAnim(cmd, "widen", MycroftEyes::WIDEN)) {
 		return;
 	} else if (checkEyeAnim(cmd, "unlook", MycroftEyes::UNLOOK)) {
+		return;
+	} else if (checkEyeAnim(cmd, "spin", MycroftEyes::SPIN)) {
 		return;
         }
 }

--- a/lib/MycroftArduino/MycroftArduino.h
+++ b/lib/MycroftArduino/MycroftArduino.h
@@ -7,7 +7,7 @@
 #define STR(tok)			STR_EXPAND(tok)
 #define ENCLOSURE_VERSION_MAJOR         0
 #define ENCLOSURE_VERSION_MINOR         3
-#define ENCLOSURE_VERSION_REVISION      0
+#define ENCLOSURE_VERSION_REVISION      1
 #define ENCLOSURE_VERSION_STRING        STR(ENCLOSURE_VERSION_MAJOR) \
                                         "." STR(ENCLOSURE_VERSION_MINOR) \
                                         "." STR(ENCLOSURE_VERSION_REVISION)

--- a/lib/MycroftEyes/MycroftEyes.cpp
+++ b/lib/MycroftEyes/MycroftEyes.cpp
@@ -118,14 +118,14 @@ void MycroftEyes::fill(uint8_t pixel) {
                 // prevent animation from overwritting
 		currentAnim = NONE;
 		currentState = CUSTOM;
-            
+
                 uint16_t i = 0;
 		for (; i <= pixel; i++) {
 			neoPixel.setPixelColor(i, color);
 			neoPixel.show();
 			delay(1);  // avoid Neopixel overload
 		}
-		
+
 		// Empty the remainder
 		for (; i < neoPixel.numPixels(); i++) {
 			neoPixel.setPixelColor(i, 0);

--- a/lib/MycroftMouth/MycroftMouth.cpp
+++ b/lib/MycroftMouth/MycroftMouth.cpp
@@ -194,24 +194,24 @@ void MycroftMouth::showIcon(const String& icon) {
 	// The low bit is the first pixel, running top to bottom
 	if (c+2 > (int)icon.length())
 		return;
-        
+
         // NOTE: For some reason no string longer than 48 characters is
         // coming through.
-        
+
 //	String	strY(icon.length());
 //        String  str("W=");
 //        str += strY;
 //        write(str.c_str());
 //        return;
-        
+
 	byte	w = icon[c++]-'A';	// this encoding works well up to 65
 	byte 	h = icon[c++]-'A';
 
-	
+
 	if (icon.length()-c < (int)w*2)
 		return;
 
-        
+
 	char	buf[2];
 	ht1632.clear();
 	for (; w && c < icon.length(); c++)
@@ -264,7 +264,15 @@ void MycroftMouth::updateText() {
 		ht1632.clear();
 		ht1632.drawTextPgm(textBuf.c_str(), OUT_SIZE - textIdx, 2, FONT_5X4, FONT_5X4_WIDTH, FONT_5X4_HEIGHT, FONT_5X4_STEP_GLYPH);
 		ht1632.render();
-		textIdx = (textIdx + 1) % (textWd + OUT_SIZE);
+
+		if (textWd > OUT_SIZE) {
+			// scroll long text
+			textIdx = (textIdx + 1) % (textWd + OUT_SIZE);
+		}
+		else {
+			// center short text
+			textIdx = OUT_SIZE - (OUT_SIZE - textWd) / 2;
+		}
 		nextTime = millis() + 150;
 	}
 }


### PR DESCRIPTION
* Restored support for "mouth.spin" with no parameters (unintentinally removed before)
* Text sent via the "mouth.text=" command will center and not scroll if it fits on screen
* Bumped version to 3.1