### PR TITLE
Add data share option

### DIFF
--- a/lib/MycroftMenu/MycroftMenu.cpp
+++ b/lib/MycroftMenu/MycroftMenu.cpp
@@ -101,6 +101,9 @@ void MycroftMenu::drawText() {
             case OptionContainer::SSH:
                 drawOption(true, "SSH", true);
                 break;
+            case OptionContainer::LEARN:
+                drawOption(true, "LEARN", true);
+                break;
             case OptionContainer::RESET:
                 drawOption(true, "RESET", true);
                 break;
@@ -136,6 +139,14 @@ void MycroftMenu::drawText() {
             drawOption(false, "BLOCK", true);
         }
     }
+    else if (currentState == LEARN){
+        if (choice){
+            drawOption(true, "ENABLED", false);
+        }
+        else{
+            drawOption(false, "DISABLED", true);
+        }
+    }
 }
 
 void MycroftMenu::pressButton() {
@@ -159,6 +170,11 @@ void MycroftMenu::pressButton() {
                 return;
             case OptionContainer::SSH:
                 currentState = ALLOW_SSH;
+                choice = false;
+                drawText();
+                break;
+            case OptionContainer::LEARN:
+                currentState = LEARN;
                 choice = false;
                 drawText();
                 break;
@@ -194,6 +210,17 @@ void MycroftMenu::pressButton() {
             Serial.println(F("unit.disable-ssh"));
         }
         optionIndex = OptionContainer::SSH;
+        exitMenu();
+        return;
+    }
+    else if (currentState == LEARN){
+        if (choice){
+            Serial.println(F("unit.enable-learning"));
+        }
+        else {
+            Serial.println(F("unit.disable-learning"));
+        }
+        optionIndex = OptionContainer::LEARN;
         exitMenu();
         return;
     }

--- a/lib/MycroftMenu/MycroftMenu.h
+++ b/lib/MycroftMenu/MycroftMenu.h
@@ -21,7 +21,7 @@ class MycroftMenu {
 public:
     MycroftMenu(int pinCS1, int pinWR, int pinDATA, int pinENC1, int pinENC2, int pinBUTTON);
     enum menuState {
-        MAIN, BRIGHTNESS, RESET_UNIT, ALLOW_SSH
+        MAIN, BRIGHTNESS, RESET_UNIT, ALLOW_SSH, LEARN
     };
     menuState getCurrentMenu();
     void drawText();
@@ -42,7 +42,7 @@ private:
     // This defines the order of menu items
     struct OptionContainer {
         enum Option{
-            ILLUM, WIFI, REBOOT, SHUTDOWN, TEST, SSH, RESET, DEMO, EXIT, _COUNT
+            ILLUM, WIFI, REBOOT, SHUTDOWN, TEST, SSH, LEARN, RESET, DEMO, EXIT, _COUNT
         };
         Option option;
     };

--- a/protocols.txt
+++ b/protocols.txt
@@ -64,7 +64,8 @@ Generated from the menu system
    "mycroft.mark1.demo"         user selected DEMO from menu
    "unit.enable-ssh"            user selected SSH > ALLOW
    "unit.disable-ssh"           user selected SSH > BLOCK
-
+   "unit.enable-learning"       user selected LEARN > ALLOW
+   "unit.disable-learning"      user selected LEARN > OFF
 
 
 NOTES

--- a/src/enclosure.ino
+++ b/src/enclosure.ino
@@ -253,7 +253,8 @@ void loop() {
 
                             if (menu.getCurrentMenu() == MycroftMenu::MAIN
                                 || menu.getCurrentMenu() == MycroftMenu::RESET_UNIT
-                                || menu.getCurrentMenu() == MycroftMenu::ALLOW_SSH) {
+                                || menu.getCurrentMenu() == MycroftMenu::ALLOW_SSH
+                                || menu.getCurrentMenu() == MycroftMenu::LEARN) {
                                     scrollMenu(dir);
                             } else if (menu.getCurrentMenu() == MycroftMenu::BRIGHTNESS){
                                     scrollBrightness(dir);


### PR DESCRIPTION
This adds a new menu option, "DATA SHARE". It adds two new output protocols: "unit.enable-data-share" and "unit.disable-data-share".