### PR TITLE
check if platform is mark 1 on upload.sh

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -15,6 +15,8 @@
 #########################################################################
 #!/usr/bin/env bash
 
+if ! (cat /etc/mycroft/mycroft.conf | grep -qF "mycroft_mark_1"); then exit
+
 # Default script behavior
 STOPSERVICE=1   # auto stop and restart mycroft-enclosure-client
 UPDATE=0        # only upload when version info indicates necessary

--- a/upload.sh
+++ b/upload.sh
@@ -15,7 +15,7 @@
 #########################################################################
 #!/usr/bin/env bash
 
-if ! (cat /etc/mycroft/mycroft.conf | grep -qF "mycroft_mark_1"); then exit
+if ! grep -qF "mycroft_mark_1" /etc/mycroft/mycroft.conf; then exit; fi
 
 # Default script behavior
 STOPSERVICE=1   # auto stop and restart mycroft-enclosure-client


### PR DESCRIPTION
checks if the platform is mark 1 on upload.sh and exits if it's not. This will prevent enclosures like picroft to try to upload the mark 1 Arduino code which causes a spike in CPU