### PR TITLE
Preparations for 1.4.2

### DIFF
--- a/lib/MycroftArduino/MycroftArduino.h
+++ b/lib/MycroftArduino/MycroftArduino.h
@@ -22,7 +22,7 @@
 #define STR(tok)			STR_EXPAND(tok)
 #define ENCLOSURE_VERSION_MAJOR         1
 #define ENCLOSURE_VERSION_MINOR         4
-#define ENCLOSURE_VERSION_REVISION      0
+#define ENCLOSURE_VERSION_REVISION      2
 #define ENCLOSURE_VERSION_STRING        STR(ENCLOSURE_VERSION_MAJOR) \
                                         "." STR(ENCLOSURE_VERSION_MINOR) \
                                         "." STR(ENCLOSURE_VERSION_REVISION)

--- a/publish.sh
+++ b/publish.sh
@@ -51,6 +51,9 @@ function _run() {
 }
 
 init_vars
+if [[ $1 == "release" ]]; then
+    git checkout v${VERSION}
+fi
 compile_arduino_sketch
 create_tarball
 upload

--- a/verifyArduino.py
+++ b/verifyArduino.py
@@ -118,7 +118,7 @@ if not os.path.isfile(pathSketch):
 
 # Read the platform.  We should only be attempting to verify/update
 # the Arduino on a Mycroft Mark 1 platform.
-config = mycroft.configuration.ConfigurationManager.get().get("enclosure")
+config = mycroft.configuration.Configuration.get().get("enclosure")
 platform = config.get('platform')
 if platform is None:
     platform = detect_platform()


### PR DESCRIPTION
- Fix always downloading firmware to device (failing python script)
- Support locking builds to release versions
- Bump version number